### PR TITLE
CB-1074 Use milliseconds for client_upload_time instead of seconds

### DIFF
--- a/src/com/amplitude/api/AmplitudeClient.java
+++ b/src/com/amplitude/api/AmplitudeClient.java
@@ -1845,15 +1845,15 @@ public class AmplitudeClient {
 
                 // Fix time logging to match what our /tracking endpoint expects.
                 // 1. Rename `timestamp` key to `client_event_time`
-                // 2. Add `client_upload_time` as seconds since epoch
-                long uploadTimeSeconds = new Date().getTime() / 1000L;
+                // 2. Add `client_upload_time` as ms since epoch
+                long uploadTimeMs = new Date().getTime();
                 for (JSONObject event : events) {
                     if (event.has("timestamp")) {
                         event.put("client_event_time", event.getLong("timestamp"));
                         event.remove("timestamp");
                     }
 
-                    event.put("client_upload_time", uploadTimeSeconds);
+                    event.put("client_upload_time", uploadTimeMs);
                 }
 
                 final Pair<Pair<Long, Long>, JSONArray> merged = mergeEventsAndIdentifys(


### PR DESCRIPTION
## Problem
The initial JIRA task mentioned using seconds for client_upload_time, but the backend does arithmetic on the server/client/upload times that expects them all to use milliseconds. Using seconds was messing up the final corrected event timestamp so it seemed like we weren't logging any events. However, I believe the affected builds WERE logging the events, just with completely wrong timestamps.

## Solution
Use milliseconds for client_upload_time to match the units for all the time thingies 💃 

## Verification
Before: saw successful 200 responses from /tracking endpoint, but no new events showing up for user in Amplitude
After: saw successful 200 responses from /tracking endpoint, and saw new events!
